### PR TITLE
Reference dev secrets explicitly

### DIFF
--- a/.github/workflows/extract-solution.yml
+++ b/.github/workflows/extract-solution.yml
@@ -16,7 +16,6 @@ jobs:
   export:
     name: Export solution
     runs-on: ubuntu-latest
-    environment: build
     concurrency: extract-solution
 
     steps:
@@ -26,12 +25,12 @@ jobs:
 
     - uses: Azure/login@v1
       with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
+        creds: ${{ secrets.AZURE_CREDENTIALS_DEV }}
 
     - uses: DfE-Digital/keyvault-yaml-secret@v1.0.1
       id: CRM
       with:
-        keyvault: ${{ secrets.KEYVAULT_NAME }}
+        keyvault: ${{ secrets.KEY_VAULT_DEV }}
         secret: CRM
         key: CRM_URL, CRM_APP_ID, CRM_APP_SECRET, CRM_TENANT_ID
 


### PR DESCRIPTION
The previous 'environment' binding means GitHub assumes this action is
deploying to 'build'. We're not deploying at all here; we're extracting
a solution only.

This removes the environment to avoid the deployment record being
incorrectly created.